### PR TITLE
Expose extra headers

### DIFF
--- a/mail_cleaner/mail.py
+++ b/mail_cleaner/mail.py
@@ -4,7 +4,7 @@ Utility layer on top of :mod:`django.core.mail`.
 import logging
 from email.mime.image import MIMEImage
 from io import StringIO
-from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple
 from urllib.request import urlopen
 
 from django.core.mail import EmailMultiAlternatives, get_connection
@@ -31,6 +31,7 @@ def send_mail_plus(
     connection=None,
     html_message: Optional[str] = None,
     attachments: Optional[Iterable["_AttachmentTuple"]] = None,
+    headers: Optional[Dict[str, str]] = None,
 ) -> int:
     """
     Send outgoing email.
@@ -47,8 +48,14 @@ def send_mail_plus(
         password=auth_password,
         fail_silently=fail_silently,
     )
+    headers = headers or {}
     mail = EmailMultiAlternatives(
-        subject, message, from_email, recipient_list, connection=connection
+        subject,
+        message,
+        from_email,
+        recipient_list,
+        connection=connection,
+        headers=headers,
     )
     if html_message:
         html_message, mime_images = replace_datauri_images(html_message)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -47,3 +47,5 @@ TEMPLATES = [
 ]
 
 ROOT_URLCONF = "testapp.urls"
+
+USE_TZ = True

--- a/tests/test_send_mail_plus.py
+++ b/tests/test_send_mail_plus.py
@@ -22,6 +22,7 @@ def test_send_mail_plus(mailoutbox):
         ["foo@bar.baz"],
         html_message=html_message,
         attachments=attachments,
+        headers={"X-Custom-Header": "foo"},
     )
 
     assert len(mailoutbox) == 1
@@ -30,6 +31,7 @@ def test_send_mail_plus(mailoutbox):
     assert message.subject == "My Subject"
     assert message.recipients() == ["foo@bar.baz"]
     assert message.from_email == "foo@sender.com"
+    assert message.extra_headers["X-Custom-Header"] == "foo"
 
     # text
     assert message.body == "My Message\n"


### PR DESCRIPTION
This exposes the header parameter of `EmailMultiAlternatives`
This also enables setting other parameters like bcc, cc, reply_to as
they are just other headers. See [RFC 2076](https://www.rfc-editor.org/rfc/rfc2076).

NB this does *not* enable callers to set content headers for
Body Parts in the body; i.e. a multi-lingual email with multipart
alternatives each with a different Content-Language is still not possible.

The Mozilla MUA code has some clear, simple examples of what email can
look like:
https://hg.mozilla.org/comm-central/file/5dbf638616e2/mailnews/test/data