### PR TITLE
Confirm Django 4.2 and Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10']
-        django: ['3.2', '4.0', '4.1']
+        python: ['3.8', '3.9', '3.10', '3.11']
+        django: ['3.2', '4.1', '4.2']
+        exclude:
+          - python: '3.11'
+            django: '3.2'
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,8 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
@@ -28,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{38,39,310}-django{32,40,41}
+    py{38,39,310}-django{32,41}
+    py{38,39,310,311}-django{42}
     isort
     black
     flake8
@@ -12,12 +13,13 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =
     3.2: django32
-    4.0: django40
     4.1: django41
+    4.2: django42
 
 [testenv]
 setenv =
@@ -28,8 +30,8 @@ extras =
     coverage
 deps =
   django32: Django~=3.2.0
-  django40: Django~=4.0.0
   django41: Django~=4.1.0
+  django42: Django~=4.2.0
 commands =
   py.test tests \
    --cov --cov-report xml:reports/coverage-{envname}.xml \


### PR DESCRIPTION
This also drops support for Django 4.1 which is EOL.